### PR TITLE
Add Drone CI pipeline

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,0 +1,66 @@
+{
+  kind: 'pipeline',
+  name: 'build',
+  platform: {
+    os: 'linux',
+    arch: 'amd64',
+  },
+
+
+  local golang = {
+    name: 'golang',
+    image: 'golang:1.12',
+    pull: 'always',
+    environment: {
+      CGO_ENABLED: '0',
+      GO111MODULE: 'on',
+      GOPROXY: 'https://proxy.golang.org',
+    },
+  },
+
+  local docker = {
+    name: 'docker',
+    image: 'plugins/docker',
+    settings+: {
+      registry: 'quay.io',
+      repo: 'quay.io/%s',
+      username: {
+        from_secret: 'quay_username',
+      },
+      password: {
+        from_secret: 'quay_password',
+      },
+    },
+    when: {
+      branch: [
+        'master',
+      ],
+    },
+  },
+
+  steps: [
+    golang {
+      name: 'build',
+      commands: [
+        'make build',
+        // 'make test',
+      ],
+    },
+
+    // golang {
+    //   name: 'generate',
+    //   commands: [
+    //     'make check-license',
+    //     'make generate',
+    //     'git diff --exit-code',
+    //   ],
+    // },
+
+    docker {
+      name: 'signalcd-api',
+      settings+: {
+        repo: 'quay.io/signalcd/api',
+      },
+    },
+  ],
+}

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -63,5 +63,13 @@
         dockerfile: 'cmd/api/Dockerfile',
       },
     },
+
+    docker {
+      name: 'signalcd-agent',
+      settings+: {
+        repo: 'quay.io/signalcd/agent',
+        dockerfile: 'cmd/agent/Dockerfile',
+      },
+    },
   ],
 }

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -63,6 +63,7 @@
       settings+: {
         repo: 'quay.io/signalcd/%s' % name,
         dockerfile: 'cmd/%s/Dockerfile' % name,
+        context: './cmd/%s/' % name,
       },
     }
     for name in ['api', 'agent']

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -45,6 +45,18 @@
         'make build',
       ],
     },
+    {
+      name: 'dart',
+      image: 'google/dart:2.3',
+      pull: 'always',
+      commands: [
+        'cd ui',
+        'pub get --no-precompile',
+        'pub global activate webdev',
+        '~/.pub-cache/bin/webdev build',
+        'rm -rf build/packages',
+      ],
+    },
   ] + [
     docker {
       name: 'docker-%s' % name,

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -33,7 +33,6 @@
     when: {
       branch: [
         'master',
-        'drone',
       ],
     },
   },

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -43,33 +43,16 @@
       name: 'build',
       commands: [
         'make build',
-        // 'make test',
       ],
     },
-
-    // golang {
-    //   name: 'generate',
-    //   commands: [
-    //     'make check-license',
-    //     'make generate',
-    //     'git diff --exit-code',
-    //   ],
-    // },
-
+  ] + [
     docker {
-      name: 'docker-api',
+      name: 'docker-%s' % name,
       settings+: {
-        repo: 'quay.io/signalcd/api',
-        dockerfile: 'cmd/api/Dockerfile',
+        repo: 'quay.io/signalcd/%s' % name,
+        dockerfile: 'cmd/%s/Dockerfile' % name,
       },
-    },
-
-    docker {
-      name: 'docker-agent',
-      settings+: {
-        repo: 'quay.io/signalcd/agent',
-        dockerfile: 'cmd/agent/Dockerfile',
-      },
-    },
+    }
+    for name in ['api', 'agent']
   ],
 }

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -6,7 +6,6 @@
     arch: 'amd64',
   },
 
-
   local golang = {
     name: 'golang',
     image: 'golang:1.12',
@@ -34,6 +33,7 @@
     when: {
       branch: [
         'master',
+        'drone',
       ],
     },
   },
@@ -60,6 +60,7 @@
       name: 'signalcd-api',
       settings+: {
         repo: 'quay.io/signalcd/api',
+        dockerfile: 'cmd/api/Dockerfile',
       },
     },
   ],

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -57,7 +57,7 @@
     // },
 
     docker {
-      name: 'signalcd-api',
+      name: 'docker-api',
       settings+: {
         repo: 'quay.io/signalcd/api',
         dockerfile: 'cmd/api/Dockerfile',
@@ -65,7 +65,7 @@
     },
 
     docker {
-      name: 'signalcd-agent',
+      name: 'docker-agent',
       settings+: {
         repo: 'quay.io/signalcd/agent',
         dockerfile: 'cmd/agent/Dockerfile',

--- a/.drone.yml
+++ b/.drone.yml
@@ -41,7 +41,6 @@ steps:
   when:
     branch:
     - master
-    - drone
 
 - name: docker-agent
   image: plugins/docker
@@ -57,6 +56,5 @@ steps:
   when:
     branch:
     - master
-    - drone
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -17,7 +17,7 @@ steps:
     GO111MODULE: on
     GOPROXY: https://proxy.golang.org
 
-- name: signalcd-api
+- name: docker-api
   image: plugins/docker
   settings:
     dockerfile: cmd/api/Dockerfile
@@ -32,7 +32,7 @@ steps:
     - master
     - drone
 
-- name: signalcd-agent
+- name: docker-agent
   image: plugins/docker
   settings:
     dockerfile: cmd/agent/Dockerfile

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,33 @@
+---
+kind: pipeline
+name: build
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: build
+  pull: always
+  image: golang:1.12
+  commands:
+  - make build
+  environment:
+    CGO_ENABLED: 0
+    GO111MODULE: on
+    GOPROXY: https://proxy.golang.org
+
+- name: signalcd-api
+  image: plugins/docker
+  settings:
+    password:
+      from_secret: quay_password
+    registry: quay.io
+    repo: quay.io/signalcd/api
+    username:
+      from_secret: quay_username
+  when:
+    branch:
+    - master
+
+...

--- a/.drone.yml
+++ b/.drone.yml
@@ -17,6 +17,16 @@ steps:
     GO111MODULE: on
     GOPROXY: https://proxy.golang.org
 
+- name: dart
+  pull: always
+  image: google/dart:2.3
+  commands:
+  - cd ui
+  - pub get --no-precompile
+  - pub global activate webdev
+  - ~/.pub-cache/bin/webdev build
+  - rm -rf build/packages
+
 - name: docker-api
   image: plugins/docker
   settings:

--- a/.drone.yml
+++ b/.drone.yml
@@ -20,6 +20,7 @@ steps:
 - name: signalcd-api
   image: plugins/docker
   settings:
+    dockerfile: cmd/api/Dockerfile
     password:
       from_secret: quay_password
     registry: quay.io
@@ -29,5 +30,6 @@ steps:
   when:
     branch:
     - master
+    - drone
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -32,4 +32,19 @@ steps:
     - master
     - drone
 
+- name: signalcd-agent
+  image: plugins/docker
+  settings:
+    dockerfile: cmd/agent/Dockerfile
+    password:
+      from_secret: quay_password
+    registry: quay.io
+    repo: quay.io/signalcd/agent
+    username:
+      from_secret: quay_username
+  when:
+    branch:
+    - master
+    - drone
+
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -30,6 +30,7 @@ steps:
 - name: docker-api
   image: plugins/docker
   settings:
+    context: ./cmd/api/
     dockerfile: cmd/api/Dockerfile
     password:
       from_secret: quay_password
@@ -45,6 +46,7 @@ steps:
 - name: docker-agent
   image: plugins/docker
   settings:
+    context: ./cmd/agent/
     dockerfile: cmd/agent/Dockerfile
     password:
       from_secret: quay_password

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# SignalCD
+# SignalCD [![Build Status](https://cloud.drone.io/api/badges/signalcd/signalcd/status.svg)](https://cloud.drone.io/signalcd/signalcd)
 
 Continuous Delivery for Kubernetes reacting to Observability Signals.

--- a/cmd/agent/Dockerfile
+++ b/cmd/agent/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine
 
-COPY ./agent /usr/bin/
+COPY ./agent /usr/bin/agent
 
 ENTRYPOINT ["/usr/bin/agent"]

--- a/ui/pubspec.lock
+++ b/ui/pubspec.lock
@@ -7,35 +7,35 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.34.3"
+    version: "0.35.4"
   angular:
     dependency: "direct main"
     description:
       name: angular
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.0"
+    version: "5.3.0"
   angular_ast:
     dependency: transitive
     description:
       name: angular_ast
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.8"
+    version: "0.5.9"
   angular_compiler:
     dependency: transitive
     description:
       name: angular_compiler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   angular_test:
     dependency: "direct dev"
     description:
       name: angular_test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   archive:
     dependency: transitive
     description:
@@ -77,7 +77,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.4"
   build_config:
     dependency: transitive
     description:
@@ -91,49 +91,49 @@ packages:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3"
+    version: "0.5.0"
   build_modules:
     dependency: transitive
     description:
       name: build_modules
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.10"
+    version: "2.1.2"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3"
+    version: "1.0.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.3"
+    version: "1.3.3"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   build_test:
     dependency: "direct dev"
     description:
       name: build_test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.6"
+    version: "0.10.7+3"
   build_web_compilers:
     dependency: "direct dev"
     description:
       name: build_web_compilers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.4+3"
+    version: "2.0.0"
   built_collection:
     dependency: transitive
     description:
@@ -210,7 +210,7 @@ packages:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.9+1"
+    version: "0.1.14"
   glob:
     dependency: transitive
     description:
@@ -294,7 +294,7 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.9+1"
+    version: "0.3.14"
   logging:
     dependency: transitive
     description:
@@ -308,7 +308,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.3+1"
+    version: "0.12.5"
   meta:
     dependency: transitive
     description:
@@ -365,13 +365,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.0"
-  plugin:
-    dependency: transitive
-    description:
-      name: plugin
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.2.0+3"
   pool:
     dependency: transitive
     description:
@@ -511,21 +504,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.3"
+    version: "1.6.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.2"
+    version: "0.2.5"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1+1"
+    version: "0.2.5"
   timing:
     dependency: transitive
     description:
@@ -569,4 +562,4 @@ packages:
     source: hosted
     version: "2.1.15"
 sdks:
-  dart: ">=2.2.0 <3.0.0"
+  dart: ">=2.3.0-dev.0.1 <3.0.0"

--- a/ui/pubspec.yaml
+++ b/ui/pubspec.yaml
@@ -6,11 +6,11 @@ environment:
   sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
-  angular: ^5.0.0
+  angular: ^5.3.0
 
 dev_dependencies:
-  angular_test: ^2.0.0
-  build_runner: ^1.1.2
-  build_test: ^0.10.2
-  build_web_compilers: ^0.4.0
-  test: ^1.0.0
+  angular_test: ^2.3.0
+  build_runner: ^1.3.0
+  build_test: ^0.10.7
+  build_web_compilers: ^2.0.0
+  test: ^1.3.0


### PR DESCRIPTION
This initial Drone pipeline will run `make build` to compile the Go binaries. Then it will compile the Dart bases `main.js` file and in the end it will build two docker images and push them to quay.io as https://quay.io/repository/signalcd/api and https://quay.io/repository/signalcd/agent

/cc @cbrgm 