### PR TITLE
Use bbolt as database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@
 /cmd/api/api
 /cmd/plugins/kubernetes-status/kubernetes-status
 /development/caddy
+/development/data
 /vendor/

--- a/database/boltdb/boltdb.go
+++ b/database/boltdb/boltdb.go
@@ -15,10 +15,12 @@ const (
 	bucketPipelines   = `pipelines`
 )
 
+// BoltDB has a connection to the database and implements the needed interfaces.
 type BoltDB struct {
 	db *bolt.DB
 }
 
+// New creates a new BoltDB instance
 func New() (*BoltDB, func() error, error) {
 	// TODO: Make path configurable
 	db, err := bolt.Open("./development/data", 0666, nil)
@@ -64,7 +66,8 @@ func New() (*BoltDB, func() error, error) {
 	return &BoltDB{db: db}, db.Close, nil
 }
 
-func (bdb *BoltDB) List() ([]signalcd.Deployment, error) {
+// ListDeployments lists all Deployments
+func (bdb *BoltDB) ListDeployments() ([]signalcd.Deployment, error) {
 	var ds []signalcd.Deployment
 
 	err := bdb.db.View(func(tx *bolt.Tx) error {
@@ -86,6 +89,7 @@ func (bdb *BoltDB) List() ([]signalcd.Deployment, error) {
 	return ds, nil
 }
 
+// CreateDeployment creates a new Deployment from a Pipeline
 func (bdb *BoltDB) CreateDeployment(pipeline signalcd.Pipeline) (signalcd.Deployment, error) {
 	var d signalcd.Deployment
 
@@ -116,6 +120,7 @@ func (bdb *BoltDB) CreateDeployment(pipeline signalcd.Pipeline) (signalcd.Deploy
 	return d, err
 }
 
+// GetCurrentDeployment gets the current Deployment
 func (bdb *BoltDB) GetCurrentDeployment() (signalcd.Deployment, error) {
 	var value []byte
 
@@ -147,6 +152,7 @@ func (bdb *BoltDB) GetCurrentDeployment() (signalcd.Deployment, error) {
 	return d, err
 }
 
+// GetPipeline gets a Pipeline by its ID
 func (bdb *BoltDB) GetPipeline(id string) (signalcd.Pipeline, error) {
 	var p signalcd.Pipeline
 
@@ -163,6 +169,7 @@ func (bdb *BoltDB) GetPipeline(id string) (signalcd.Pipeline, error) {
 	return p, err
 }
 
+// ListPipelines returns a list of Pipelines
 func (bdb *BoltDB) ListPipelines() ([]signalcd.Pipeline, error) {
 	var pipelines []signalcd.Pipeline
 

--- a/database/boltdb/boltdb.go
+++ b/database/boltdb/boltdb.go
@@ -1,0 +1,130 @@
+package boltdb
+
+import (
+	"encoding/json"
+	"strconv"
+	"time"
+
+	"github.com/signalcd/signalcd/api"
+	"github.com/signalcd/signalcd/signalcd"
+	bolt "go.etcd.io/bbolt"
+	"golang.org/x/xerrors"
+)
+
+type BoltDB struct {
+	db *bolt.DB
+}
+
+func New() (*BoltDB, func() error, error) {
+	// TODO: Make path configurable
+	db, err := bolt.Open("./development/data", 0666, nil)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("failed to open bolt db: %w", err)
+	}
+
+	err = db.Batch(func(tx *bolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists([]byte(`deployments`))
+		if err != nil {
+			return err
+		}
+
+		for _, d := range api.FakeDeployments {
+			key := strconv.Itoa(int(d.Number))
+			value, _ := json.Marshal(d)
+
+			if err := bucket.Put([]byte(key), value); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &BoltDB{db: db}, db.Close, nil
+}
+
+func (bdb *BoltDB) List() ([]signalcd.Deployment, error) {
+	var ds []signalcd.Deployment
+
+	err := bdb.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(`deployments`))
+		c := b.Cursor()
+
+		for k, v := c.Last(); k != nil; k, v = c.Prev() {
+			var d signalcd.Deployment
+			_ = json.Unmarshal(v, &d)
+			ds = append(ds, d)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return ds, nil
+}
+
+func (bdb *BoltDB) Create(pipeline signalcd.Pipeline) (signalcd.Deployment, error) {
+	var d signalcd.Deployment
+
+	err := bdb.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(`deployments`))
+		c := b.Cursor()
+
+		num := 0
+		for k, _ := c.First(); k != nil; k, _ = c.Next() {
+			num++
+		}
+
+		d := signalcd.Deployment{
+			Number:  int64(num + 1),
+			Created: time.Now(),
+			Status: signalcd.DeploymentStatus{
+				Phase: signalcd.Unknown,
+			},
+			Pipeline: pipeline,
+		}
+
+		key := strconv.Itoa(int(d.Number))
+		value, _ := json.Marshal(d)
+
+		return b.Put([]byte(key), value)
+	})
+
+	return d, err
+}
+
+func (bdb *BoltDB) GetCurrentDeployment() (signalcd.Deployment, error) {
+	var value []byte
+
+	err := bdb.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(`deployments`))
+		c := b.Cursor()
+
+		num := 0
+		for k, v := c.Last(); k != nil; k, v = c.Prev() {
+			i, err := strconv.Atoi(string(k))
+			if err != nil {
+				return err
+			}
+
+			if num < i {
+				num = i
+				value = v
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return signalcd.Deployment{}, err
+	}
+
+	var d signalcd.Deployment
+	err = json.Unmarshal(value, &d)
+	return d, err
+}

--- a/database/boltdb/fake.go
+++ b/database/boltdb/fake.go
@@ -1,0 +1,92 @@
+package boltdb
+
+import (
+	"time"
+
+	"github.com/signalcd/signalcd/signalcd"
+)
+
+var fakeDeployments = []signalcd.Deployment{
+	{
+		Number:  4,
+		Created: time.Now().Add(-30 * time.Second),
+		Status: signalcd.DeploymentStatus{
+			Phase: signalcd.Success,
+		},
+		Pipeline: fakePipelines[2],
+	},
+	{
+		Number:  3,
+		Created: time.Now().Add(-3 * time.Minute),
+		Status: signalcd.DeploymentStatus{
+			Phase: signalcd.Success,
+		},
+		Pipeline: fakePipelines[0],
+	},
+	{
+		Number:  2,
+		Created: time.Now().Add(-8 * time.Minute),
+		Status: signalcd.DeploymentStatus{
+			Phase: signalcd.Failed,
+		},
+		Pipeline: fakePipelines[1],
+	},
+	{
+		Number:  1,
+		Created: time.Now().Add(-10 * time.Minute),
+		Status: signalcd.DeploymentStatus{
+			Phase: signalcd.Success,
+		},
+		Pipeline: fakePipelines[0],
+	},
+}
+
+var fakePipelines = []signalcd.Pipeline{
+	{
+		ID:   "eee4047d-3826-4bf0-a7f1-b0b339521a52",
+		Name: "cheese0",
+		Steps: []signalcd.Step{
+			{
+				Name:     "cheese0",
+				Image:    "quay.io/signalcd/examples:cheese0",
+				Commands: []string{"kubectl apply -f /data"},
+			},
+		},
+		Checks: fakeChecks,
+	},
+	{
+		ID:   "6151e283-99b6-4611-bbc4-8aa4d3ddf8fd",
+		Name: "cheese1",
+		Steps: []signalcd.Step{
+			{
+				Name:     "cheese1",
+				Image:    "quay.io/signalcd/examples:cheese1",
+				Commands: []string{"kubectl apply -f /data"},
+			},
+		},
+		Checks: fakeChecks,
+	},
+	{
+		ID:   "a7cae189-400e-4d8c-a982-f0e9a5b4901f",
+		Name: "cheese2",
+		Steps: []signalcd.Step{
+			{
+				Name:     "cheese2",
+				Image:    "quay.io/signalcd/examples:cheese2",
+				Commands: []string{"kubectl apply -f /data"},
+			},
+		},
+		Checks: fakeChecks,
+	},
+}
+
+var fakeChecks = []signalcd.Check{
+	{
+		Name:     "kubernetes-status",
+		Image:    "quay.io/signalcd/kubernetes-status",
+		Duration: time.Minute,
+		Environment: map[string]string{
+			"PLUGIN_LABELS": "app=cheese",
+		},
+	},
+}

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/oklog/run v1.0.0
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/urfave/cli v1.20.0
+	go.etcd.io/bbolt v1.3.2
 	golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734 // indirect
 	golang.org/x/net v0.0.0-20190424112056-4829fb13d2c6
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+go.etcd.io/bbolt v1.3.2 h1:Z/90sZLPOeCy2PwprqkFa25PdkusRzaj9P8zm/KNyvk=
+go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190320223903-b7391e95e576/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734 h1:p/H982KKEjUnLJkM3tt/LemDnOc1GiZL5FCVlORJ5zo=


### PR DESCRIPTION
Instead of the in memory version we can use bbolt as database to persist some data. This should get us already quite far. In the future we can work on replacing those interfaces with a SQL database, like Cockroach DB, for example.

/cc @cbrgm 