### PR TITLE
Publish Deployment Events via ServerSentEvents (SSE)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,11 +1,15 @@
 package api
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/go-chi/chi"
 	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"github.com/go-openapi/loads"
 	restmiddleware "github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
@@ -28,8 +32,13 @@ type SignalDB interface {
 	PipelineCreator
 }
 
+type Events interface {
+	SubscribeDeployments(channel chan signalcd.Deployment) signalcd.Subscription
+	UnsubscribeDeployments(s signalcd.Subscription)
+}
+
 // NewV1 creates a new v1 API
-func NewV1(db SignalDB, logger log.Logger) (*chi.Mux, error) {
+func NewV1(logger log.Logger, db SignalDB, events Events) (*chi.Mux, error) {
 	router := chi.NewRouter()
 
 	// load embedded swagger file
@@ -56,7 +65,58 @@ func NewV1(db SignalDB, logger log.Logger) (*chi.Mux, error) {
 
 	router.Mount("/", api.Serve(nil))
 
+	router.Get("/api/v1/deployments/events", deploymentEventsHandler(logger, events))
+
 	return router, nil
+}
+
+func deploymentEventsHandler(logger log.Logger, events Events) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "Streaming unsupported!", http.StatusMethodNotAllowed)
+			return
+		}
+
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+
+		level.Debug(logger).Log("msg", "streaming deployment http connection just opened")
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+
+		deploymentEvents := make(chan signalcd.Deployment, 8)
+		subscription := events.SubscribeDeployments(deploymentEvents)
+
+		defer func() {
+			events.UnsubscribeDeployments(subscription)
+			level.Debug(logger).Log("msg", "streaming deployment http connection just closed")
+		}()
+
+		for {
+			select {
+			case <-ctx.Done():
+				close(deploymentEvents)
+				return
+			case deployment := <-deploymentEvents:
+				model := getModelsDeployment(deployment)
+				j, err := json.Marshal(model)
+				if err != nil {
+					return // TODO
+				}
+
+				_, err = fmt.Fprintf(w, "data: %s\n\n", j)
+				if err != nil {
+					return // TODO
+				}
+
+				flusher.Flush()
+			}
+		}
+	}
 }
 
 func getModelsPipeline(p signalcd.Pipeline) *models.Pipeline {

--- a/api/api.go
+++ b/api/api.go
@@ -32,6 +32,7 @@ type SignalDB interface {
 	PipelineCreator
 }
 
+// Events to Deployments that should be sent via SSE (Server Sent Events)
 type Events interface {
 	SubscribeDeployments(channel chan signalcd.Deployment) signalcd.Subscription
 	UnsubscribeDeployments(s signalcd.Subscription)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -110,24 +109,6 @@ func apiAction(logger log.Logger) cli.ActionFunc {
 			}, func(err error) {
 				_ = l.Close()
 			})
-		}
-		{
-			for i := 0; i < 3; i++ {
-				deployments := make(chan signalcd.Deployment)
-				subscription := events.SubscribeDeployments(deployments)
-
-				gr.Add(func(i int) func() error {
-					return func() error {
-						for d := range deployments {
-							fmt.Printf("deployment event %d: %+v\n", i, d)
-						}
-						return nil
-					}
-				}(i), func(err error) {
-					events.UnsubscribeDeployments(subscription)
-				},
-				)
-			}
 		}
 
 		if err := gr.Run(); err != nil {

--- a/database/boltdb/events.go
+++ b/database/boltdb/events.go
@@ -6,11 +6,13 @@ import (
 	"github.com/signalcd/signalcd/signalcd"
 )
 
+// Events wraps BoltDB to publish updated structs
 type Events struct {
 	*BoltDB
 	events *signalcd.Events
 }
 
+// NewEvents creates a new BoltDB wrapper that publishes events
 func NewEvents(db *BoltDB, events *signalcd.Events) *Events {
 	return &Events{
 		BoltDB: db,
@@ -18,6 +20,7 @@ func NewEvents(db *BoltDB, events *signalcd.Events) *Events {
 	}
 }
 
+// CreateDeployment wraps the underlying BoltDB func to publish successfully created Deployments
 func (e *Events) CreateDeployment(pipeline signalcd.Pipeline) (signalcd.Deployment, error) {
 	deployment, err := e.BoltDB.CreateDeployment(pipeline)
 
@@ -28,6 +31,7 @@ func (e *Events) CreateDeployment(pipeline signalcd.Pipeline) (signalcd.Deployme
 	return deployment, err
 }
 
+// SetDeploymentStatus wraps t he underlying BoltDB func to publish successfully updated Deployments
 func (e *Events) SetDeploymentStatus(ctx context.Context, number int64, phase signalcd.DeploymentPhase) (signalcd.Deployment, error) {
 	deployment, err := e.BoltDB.SetDeploymentStatus(ctx, number, phase)
 

--- a/database/boltdb/events.go
+++ b/database/boltdb/events.go
@@ -1,0 +1,39 @@
+package boltdb
+
+import (
+	"context"
+
+	"github.com/signalcd/signalcd/signalcd"
+)
+
+type Events struct {
+	*BoltDB
+	events *signalcd.Events
+}
+
+func NewEvents(db *BoltDB, events *signalcd.Events) *Events {
+	return &Events{
+		BoltDB: db,
+		events: events,
+	}
+}
+
+func (e *Events) CreateDeployment(pipeline signalcd.Pipeline) (signalcd.Deployment, error) {
+	deployment, err := e.BoltDB.CreateDeployment(pipeline)
+
+	if err == nil {
+		e.events.PublishDeployment(deployment)
+	}
+
+	return deployment, err
+}
+
+func (e *Events) SetDeploymentStatus(ctx context.Context, number int64, phase signalcd.DeploymentPhase) (signalcd.Deployment, error) {
+	deployment, err := e.BoltDB.SetDeploymentStatus(ctx, number, phase)
+
+	if err == nil {
+		e.events.PublishDeployment(deployment)
+	}
+
+	return deployment, err
+}

--- a/signalcd/events.go
+++ b/signalcd/events.go
@@ -1,0 +1,49 @@
+package signalcd
+
+import (
+	"sync"
+)
+
+type Events struct {
+	deploymentSubscribers map[int64]chan Deployment
+	deploymentLock        sync.RWMutex
+
+	pipelineSubscribers map[int64]chan Pipeline
+	pipelineLock        sync.RWMutex
+}
+
+func NewEvents() *Events {
+	return &Events{
+		deploymentSubscribers: make(map[int64]chan Deployment),
+		pipelineSubscribers:   make(map[int64]chan Pipeline),
+	}
+}
+
+type Subscription struct {
+	id int64
+}
+
+func (e *Events) SubscribeDeployments(channel chan Deployment) Subscription {
+	e.deploymentLock.Lock()
+	defer e.deploymentLock.Unlock()
+
+	id := int64(len(e.deploymentSubscribers)) + 1
+	e.deploymentSubscribers[id] = channel
+	return Subscription{id: id}
+}
+
+func (e *Events) UnsubscribeDeployments(s Subscription) {
+	e.deploymentLock.Lock()
+	defer e.deploymentLock.Unlock()
+
+	delete(e.deploymentSubscribers, s.id)
+}
+
+func (e *Events) PublishDeployment(d Deployment) {
+	e.deploymentLock.RLock()
+	defer e.deploymentLock.RUnlock()
+
+	for _, s := range e.deploymentSubscribers {
+		s <- d
+	}
+}

--- a/signalcd/events_test.go
+++ b/signalcd/events_test.go
@@ -1,0 +1,55 @@
+package signalcd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventsDeploymentsSubscription(t *testing.T) {
+	events := NewEvents()
+	assert.Len(t, events.deploymentSubscribers, 0)
+	subs1 := events.SubscribeDeployments(make(chan Deployment))
+	assert.Len(t, events.deploymentSubscribers, 1)
+	subs2 := events.SubscribeDeployments(make(chan Deployment))
+	assert.Len(t, events.deploymentSubscribers, 2)
+	events.UnsubscribeDeployments(subs1)
+	assert.Len(t, events.deploymentSubscribers, 1)
+	events.UnsubscribeDeployments(subs2)
+	assert.Len(t, events.deploymentSubscribers, 0)
+}
+
+func TestEventsDeploymentOneSubscriber(t *testing.T) {
+	events := NewEvents()
+	channel := make(chan Deployment, 1)
+	_ = events.SubscribeDeployments(channel)
+
+	events.PublishDeployment(Deployment{Number: 123})
+
+	d := <-channel
+	assert.Equal(t, int64(123), d.Number)
+}
+
+func TestEventsDeploymentMultipleSubscribers(t *testing.T) {
+	events := NewEvents()
+	channel1 := make(chan Deployment, 1)
+	_ = events.SubscribeDeployments(channel1)
+	channel2 := make(chan Deployment, 1)
+	_ = events.SubscribeDeployments(channel2)
+
+	events.PublishDeployment(Deployment{Number: 123})
+
+	d1 := <-channel1
+	assert.Equal(t, int64(123), d1.Number)
+
+	d2 := <-channel2
+	assert.Equal(t, int64(123), d2.Number)
+
+	events.PublishDeployment(Deployment{Number: 666})
+
+	d1 = <-channel1
+	assert.Equal(t, int64(666), d1.Number)
+
+	d2 = <-channel2
+	assert.Equal(t, int64(666), d2.Number)
+}


### PR DESCRIPTION
This replaces constant polling with a 1s interval. Every time there is a successful write to a Deployment (create, update) in the BoltDB we will push a server sent event to all long lived requests.

We essentially wrap the BoltDB store by embedding the SignalDB interface and the implementing some of the methods again and shadowing the calls. Once a call to BoltDB doesn't return an error, we write to a channel, that fans out that event to all subscribed callback functions.

/cc @cbrgm @aditya-konarde