### PR TITLE
Use drone/envsubst to substitute env vars in YAML config

### DIFF
--- a/cmd/plugins/drone/main.go
+++ b/cmd/plugins/drone/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	stdlog "log"
 	"net/url"
 	"os"
@@ -52,12 +53,12 @@ func main() {
 
 func action(c *cli.Context) error {
 	path := c.String("signalcd.file")
-	file, err := os.Open(path)
+	fileContent, err := ioutil.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("failed to read SignalCD file from: %s", path)
 	}
 
-	config, err := signalcd.ParseConfig(file)
+	config, err := signalcd.ParseConfig(string(fileContent))
 	if err != nil {
 		return fmt.Errorf("failed to parse SignalCD config: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/signalcd/signalcd
 go 1.12
 
 require (
+	github.com/drone/envsubst v1.0.2
 	github.com/go-chi/chi v4.0.2+incompatible
 	github.com/go-kit/kit v0.8.0
 	github.com/go-logfmt/logfmt v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/go-units v0.3.3 h1:Xk8S3Xj5sLGlG5g67hJmYMmUgXv5N4PhkjJHHqrwnTk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/drone/envsubst v1.0.2 h1:dpYLMAspQHW0a8dZpLRKe9jCNvIGZPhCPrycZzIHdqo=
+github.com/drone/envsubst v1.0.2/go.mod h1:bkZbnc/2vh1M12Ecn7EYScpI4YGYU0etwLJICOWi8Z0=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8 h1:DujepqpGd1hyOd7aW59XpK7Qymp8iy83xq74fLr21is=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=

--- a/signalcd/config_test.go
+++ b/signalcd/config_test.go
@@ -1,9 +1,9 @@
 package signalcd
 
 import (
-	"bytes"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,27 +13,53 @@ func TestConfig(t *testing.T) {
 	testcases := []struct {
 		name   string
 		input  string
+		env    func(string) string
 		expect Config
 		error  error
 	}{
 		{
 			name:   "Empty",
 			input:  ``,
+			env:    func(s string) string { return "" },
 			expect: Config{},
 			error:  io.EOF,
 		},
 		{
 			name:   "NameOnly",
 			input:  `name: foobar`,
+			env:    func(s string) string { return "" },
 			expect: Config{Name: "foobar"},
 			error:  nil,
+		},
+		{
+			name: "StepTagEnvvar",
+			input: `
+name: foobar
+steps:
+- name: foobar
+  image: foobar:${SOME_VAR}
+		`,
+			env: func(s string) string {
+				if s == "SOME_VAR" {
+					return "baz"
+				}
+				return ""
+			},
+			expect: Config{
+				Name: "foobar",
+				Steps: []ConfigStep{{
+					Name:  "foobar",
+					Image: "foobar:baz",
+				}},
+			},
+			error: nil,
 		},
 	}
 
 	for _, tc := range testcases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			output, err := ParseConfig(bytes.NewBufferString(tc.input))
+			output, err := parseConfigEnv(strings.TrimSpace(tc.input), tc.env)
 			assert.Equal(t, tc.expect, output)
 			if tc.error == nil {
 				assert.NoError(t, err)


### PR DESCRIPTION
```yaml
name: foobar
steps:
- name: foobar
  image: foobar:${SOME_VAR}
```

will become:
```yaml
name: foobar
steps:
- name: foobar
  image: foobar:baz
```
when `SOME_VAR=baz`

/cc @cbrgm 